### PR TITLE
[Fix/#110] usingAlertView 에서 가장 가까운 버스를 찾아낸 시점에 스크롤 이동하도록 하여 해결 완료

### DIFF
--- a/BlueberrySmoothie/BlueBerrySmoothie/View/UsingAlertView.swift
+++ b/BlueberrySmoothie/BlueBerrySmoothie/View/UsingAlertView.swift
@@ -102,6 +102,11 @@ struct UsingAlertView: View {
                 startRefreshTimer() // 타이머 시작
                 refreshData() // 초기 로드
             }
+            .onChange(of: currentBusViewModel.closestBusLocation != nil) { isNotNil in
+                if isNotNil {
+                    isScrollTriggered = true
+                }
+            }
             .onDisappear {
                 currentBusViewModel.stopUpdating() // 뷰가 사라질 때 뷰모델에서 위치 업데이트 중단
                 stopRefreshTimer() // 뷰 사라질 때 타이머 중단


### PR DESCRIPTION
- onAppear를 사용하려고 했을 때, fetchData에 시간이 걸리기 때문에 스크롤 이동이 적용되지 않았음
- 그래서 currentBusViewModel의 closestBusLoacation 값이 nil값이 아니게 됐을 때, isScrollTriggered를 true로 설정함