### PR TITLE
200 fixdaisy notification 진동 주기 수정

### DIFF
--- a/BlueberrySmoothie/BlueBerrySmoothie/Manager/LocationManager.swift
+++ b/BlueberrySmoothie/BlueBerrySmoothie/Manager/LocationManager.swift
@@ -118,11 +118,11 @@ class LocationManager: NSObject, ObservableObject {
         
         
         // 앱이 포그라운드 상태일 때
-        if UIApplication.shared.applicationState == .active {
-            content.subtitle = "포그라운드 알림"
-        } else {
-            content.subtitle = "백그라운드 알림"
-        }
+//        if UIApplication.shared.applicationState == .active {
+//            content.subtitle = "포그라운드 알림"
+//        } else {
+//            content.subtitle = "백그라운드 알림"
+//        }
         
         // 고유한 식별자 생성 (시간값 포함)
         let identifier = "\(busAlert.id)_\(Date().timeIntervalSince1970)"

--- a/BlueberrySmoothie/BlueBerrySmoothie/Manager/LocationManager.swift
+++ b/BlueberrySmoothie/BlueBerrySmoothie/Manager/LocationManager.swift
@@ -65,7 +65,7 @@ class LocationManager: NSObject, ObservableObject {
         backgroundTasks[busAlert.id] = backgroundTask
         
         // 0.6초마다 반복되는 타이머 생성
-        let timer = Timer(timeInterval: 0.6, repeats: true) { [weak self] _ in
+        let timer = Timer(timeInterval: 1, repeats: true) { [weak self] _ in
             self?.scheduleNotification(for: busAlert)
         }
         RunLoop.main.add(timer, forMode: .common)
@@ -128,7 +128,7 @@ class LocationManager: NSObject, ObservableObject {
         let identifier = "\(busAlert.id)_\(Date().timeIntervalSince1970)"
         
         // 즉시 실행되는 트리거
-        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.4, repeats: false)
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
         
         let request = UNNotificationRequest(identifier: identifier,
                                             content: content,

--- a/BlueberrySmoothie/BlueBerrySmoothie/View/UsingAlertView.swift
+++ b/BlueberrySmoothie/BlueBerrySmoothie/View/UsingAlertView.swift
@@ -477,6 +477,7 @@ struct UsingAlertView: View {
                 Button(action: {
                     stopRefreshTimer() // 알람 종료 시 타이머도 중단
                     notificationManager.notificationReceived = false // 오버레이 닫기
+                    locationManager.stopAllMonitoring()
                     locationManager.unregisterBusAlert(busAlert)
                     locationManager.stopAudio()
                     dismiss()


### PR DESCRIPTION
노티 생성 주기 미세 조절 완료
-> 포어 그라운드에서는 약 3초에 한 번씩 울리지만, iOS 시스템상 배터리 등의 이유로 여러번 진동오는 것을 막는 것 같습니다.
-> 백그라운드에서는 노티 진동이 빠르게 울립니다.
-> 워치를 차고 있어도, 노티 진동이 빠르게 울립니다.

노티 서브 타이틀 삭제
-> 제가 쓴 코드는 아니지만, 누군가 테스트 하느라고 노티 서브타이틀을 '백그라운드 알림', '포그라운드 알림' 으로 작성해놓은 코드가 있었습니다.
-> 사용자가 받는 노티에 해당 텍스트가 보여지고 있기 때문에, 주석처리했습니다.